### PR TITLE
rm custom dependency checks from `setup.py`

### DIFF
--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -61,6 +61,7 @@ from __future__ import absolute_import
 import logging
 import numpy as np
 from polytope.quickhull import quickhull
+logger = logging.getLogger(__name__)
 try:
     from cvxopt import matrix, solvers
     import cvxopt.glpk
@@ -73,9 +74,11 @@ try:
 except ImportError:
     from scipy import optimize
     lp_solver = 'scipy'
+    logger.warn(
+        '`polytope` failed to import `cvxopt.glpk`.\n'
+        'Will use `scipy.optimize.linprog`.')
 
 
-logger = logging.getLogger(__name__)
 # Nicer numpy output
 np.set_printoptions(precision=5, suppress=True)
 

--- a/setup.py
+++ b/setup.py
@@ -11,29 +11,6 @@ import imp
 import os
 from setuptools import setup
 import subprocess
-import sys
-
-
-###########################################
-# Dependency or optional-checking functions
-###########################################
-# (see notes below.)
-
-# Handle "dry-check" argument to check for dependencies without
-# installing the polytope package; checking occurs by default if
-# "install" is given, unless both "install" and "nocheck" are given
-# (but typical users do not need "nocheck").
-
-other_depends = dict()
-
-# These are nice to have but not necessary. Each item is of the form
-#
-#   keys   : name of optional package;
-#   values : list of callable and two strings, first string printed on
-#           success, second printed on failure (i.e. package not
-#           found); we interpret the return value True to be success,
-#           and False failure.
-optionals = dict()
 
 
 def retrieve_git_info():
@@ -76,31 +53,7 @@ def retrieve_git_info():
     return sha1
 
 
-check_deps = False
-if 'install' in sys.argv[1:] and 'nocheck' not in sys.argv[1:]:
-    check_deps = True
-elif 'dry-check' in sys.argv[1:]:
-    perform_setup = False
-    check_deps = True
-# Pull "dry-check" and "nocheck" from argument list, if present, to play
-# nicely with Distutils setup.
-try:
-    sys.argv.remove('dry-check')
-except ValueError:
-    pass
-try:
-    sys.argv.remove('nocheck')
-except ValueError:
-    pass
-if check_deps:
-    # Optional stuff
-    for (opt_key, opt_val) in optionals.items():
-        print('Probing for optional ' + opt_key + '...')
-        if opt_val[0]():
-            print('\t' + opt_val[1])
-        else:
-            print('\t' + opt_val[2])
-
+perform_setup = True
 classifiers = [
     'Development Status :: 2 - Pre-Alpha',
     'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ def retrieve_git_info():
     return sha1
 
 
-perform_setup = True
 classifiers = [
     'Development Status :: 2 - Pre-Alpha',
     'Intended Audience :: Developers',
@@ -58,14 +57,15 @@ classifiers = [
     'Topic :: Scientific/Engineering',
     'Topic :: Software Development']
 
-# load long description from README.rst
-readme_file = 'README.rst'
-if os.path.exists(readme_file):
-    long_description = open(readme_file).read()
-else:
-    print('Could not find readme file to extract long_description.')
-    long_description = ''
-if perform_setup:
+
+def run_setup():
+    # load long description from README.rst
+    readme_file = 'README.rst'
+    if os.path.exists(readme_file):
+        long_description = open(readme_file).read()
+    else:
+        print('Could not find readme file to extract long_description.')
+        long_description = ''
     # If .git directory is present, create commit_hash.txt accordingly
     # to indicate version information
     if os.path.exists('.git'):
@@ -108,3 +108,7 @@ if perform_setup:
         package_dir=dict(polytope='polytope'),
         package_data=dict(polytope=['commit_hash.txt']),
         classifiers=classifiers)
+
+
+if __name__ == '__main__':
+    run_setup()

--- a/setup.py
+++ b/setup.py
@@ -142,21 +142,6 @@ if check_deps:
     if not perform_setup:
         print('Checking for required dependencies...')
         # Python package dependencies
-        try:
-            import numpy
-        except:
-            print('ERROR: NumPy not found.')
-            raise
-        try:
-            import networkx
-        except:
-            print('ERROR: NetworkX not found.')
-            raise
-        try:
-            import scipy
-        except:
-            print('ERROR: SciPy not found.')
-            raise
         # Other dependencies
         for (dep_key, dep_val) in other_depends.items():
             if not dep_val[0]():

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,6 @@ import sys
 # Dependency or optional-checking functions
 ###########################################
 # (see notes below.)
-def check_glpk():
-    try:
-        import cvxopt.glpk
-    except ImportError:
-        return False
-    return True
 
 # Handle "dry-check" argument to check for dependencies without
 # installing the polytope package; checking occurs by default if
@@ -31,10 +25,6 @@ def check_glpk():
 # (but typical users do not need "nocheck").
 
 other_depends = dict()
-glpk_msg = (
-    'GLPK seems to be missing\n'
-    'and thus apparently not used by your installation of CVXOPT.\n'
-    'If you\'re interested, see http://www.gnu.org/s/glpk/')
 
 # These are nice to have but not necessary. Each item is of the form
 #
@@ -43,8 +33,7 @@ glpk_msg = (
 #           success, second printed on failure (i.e. package not
 #           found); we interpret the return value True to be success,
 #           and False failure.
-optionals = dict(
-    glpk=[check_glpk, 'GLPK found.', glpk_msg])
+optionals = dict()
 
 
 def retrieve_git_info():

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,6 @@ def check_glpk():
     return True
 
 
-def check_mpl():
-    try:
-        import matplotlib
-    except ImportError:
-        return False
-    return True
-
 def check_cvxopt():
     try:
         import cvxopt
@@ -50,10 +43,6 @@ glpk_msg = (
     'GLPK seems to be missing\n'
     'and thus apparently not used by your installation of CVXOPT.\n'
     'If you\'re interested, see http://www.gnu.org/s/glpk/')
-mpl_msg = (
-    'matplotlib not found.\n'
-    'For many graphics drawing features, you must install\n'
-    'matplotlib (http://matplotlib.org/).')
 cvxopt_msg = (
     'CVXOPT not found.\n'
     'To utilize CVXOPT as the default linear program solver,\n'
@@ -68,8 +57,7 @@ cvxopt_msg = (
 #           and False failure.
 optionals = dict(
     cvxopt=[check_cvxopt, 'CVXOPT found.', cvxopt_msg],
-    glpk=[check_glpk, 'GLPK found.', glpk_msg],
-    matplotlib=[check_mpl, 'matplotlib found.', mpl_msg])
+    glpk=[check_glpk, 'GLPK found.', glpk_msg])
 
 
 def retrieve_git_info():

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,4 @@
 #!/usr/bin/env python
-
-# for testing on https://testpypi.python.org use:
-#
-# pip install -i https://testpypi.python.org/pypi polytope
-#             --extra-index-url https://pypi.python.org/pypi
-#
-# so that dependencies can be found and installed,
-# when testing in a clean virtualenv.
 import imp
 import os
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,19 @@ from setuptools import setup
 import subprocess
 
 
+classifiers = [
+    'Development Status :: 2 - Pre-Alpha',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: BSD License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Topic :: Scientific/Engineering',
+    'Topic :: Software Development']
+
+
 def retrieve_git_info():
     """Return commit hash of HEAD, or "release", or None if failure.
 
@@ -43,19 +56,6 @@ def retrieve_git_info():
     p.wait()
     sha1 = p.stdout.read()
     return sha1
-
-
-classifiers = [
-    'Development Status :: 2 - Pre-Alpha',
-    'Intended Audience :: Developers',
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
-    'Topic :: Scientific/Engineering',
-    'Topic :: Software Development']
 
 
 def run_setup():

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,6 @@ def check_glpk():
         return False
     return True
 
-
-def check_cvxopt():
-    try:
-        import cvxopt
-    except ImportError:
-        return False
-    return True
-
 # Handle "dry-check" argument to check for dependencies without
 # installing the polytope package; checking occurs by default if
 # "install" is given, unless both "install" and "nocheck" are given
@@ -43,10 +35,6 @@ glpk_msg = (
     'GLPK seems to be missing\n'
     'and thus apparently not used by your installation of CVXOPT.\n'
     'If you\'re interested, see http://www.gnu.org/s/glpk/')
-cvxopt_msg = (
-    'CVXOPT not found.\n'
-    'To utilize CVXOPT as the default linear program solver,\n'
-    'please install from http://cvxopt.org')
 
 # These are nice to have but not necessary. Each item is of the form
 #
@@ -56,7 +44,6 @@ cvxopt_msg = (
 #           found); we interpret the return value True to be success,
 #           and False failure.
 optionals = dict(
-    cvxopt=[check_cvxopt, 'CVXOPT found.', cvxopt_msg],
     glpk=[check_glpk, 'GLPK found.', glpk_msg])
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,15 +45,6 @@ def check_cvxopt():
 # "install" is given, unless both "install" and "nocheck" are given
 # (but typical users do not need "nocheck").
 
-# You *must* have these to use the polytope package.  Each item in
-# other_depends must be treated specially; thus other_depends is a
-# dictionary with
-#
-#   keys   : names of dependency;
-
-#   values : list of callable and string, which is printed on failure
-#           (i.e. package not found); we interpret the return value
-#           True to be success, and False failure.
 other_depends = dict()
 glpk_msg = (
     'GLPK seems to be missing\n'
@@ -121,7 +112,6 @@ def retrieve_git_info():
     return sha1
 
 
-perform_setup = True
 check_deps = False
 if 'install' in sys.argv[1:] and 'nocheck' not in sys.argv[1:]:
     check_deps = True
@@ -139,14 +129,6 @@ try:
 except ValueError:
     pass
 if check_deps:
-    if not perform_setup:
-        print('Checking for required dependencies...')
-        # Python package dependencies
-        # Other dependencies
-        for (dep_key, dep_val) in other_depends.items():
-            if not dep_val[0]():
-                print(dep_val[1])
-                raise Exception('Failed dependency: ' + dep_key)
     # Optional stuff
     for (opt_key, opt_val) in optionals.items():
         print('Probing for optional ' + opt_key + '...')


### PR DESCRIPTION
These checks were mainly inherited from `tulip`. The mandatory Python dependencies are handled by `setuptools` or `pip`. The only remaining optional ones are `matplotlib` and `cvxopt.glpk` (after #16). Both are noted in `requirements.txt` and `matplotlib` in `tests_require` too. The user expects them there. The warnings will arise anyway at import time, as traditional duck behavior. It is unlikely that the messages will be noticed during installation, and more likely that they will be seen in `requirements.txt`, or the README (will be updated on branch `master`).