### PR TITLE
Rotate with 2 vectors

### DIFF
--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -613,7 +613,7 @@ def _solve_rotation(u, v):
     if uv[0, 0] < 0:
         M[0, 0] = -1
         M[1, 1] = -1
-        uv = uv @ M
+        uv = uv.dot(M)
 
     logger.debug("u is now {}".format(uv[0]))
     logger.debug("v is now {}".format(uv[1]))
@@ -627,8 +627,8 @@ def _solve_rotation(u, v):
                 logger.debug("in the {0},{1} plane rotate {2}".format(c, c-1,
                                                                       theta))
 
-                uv = uv @ Mk
-                M = M @ Mk
+                uv = uv.dot(Mk)
+                M = M.dot(Mk)
 
                 logger.debug("u is now {}".format(uv[0]))
                 logger.debug("v is now {}".format(uv[1]))
@@ -642,7 +642,7 @@ def _solve_rotation(u, v):
     # perform M rotations in reverse order
     M_inverse = M.T
 
-    R = M @ R @ M_inverse
+    R = M.dot(R.dot(M_inverse))
     logger.debug("rotation matrix is\n{}".format(R))
 
     return R

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -595,11 +595,14 @@ def _solve_rotation(u, v):
     functions. Also, the sign of arctan2 in numpy seems to be the opposite of
     arctan2 in \citea{aguilera2004general}.
 
-    @article{aguilera2004general,
-      title={General n-dimensional rotations},
-      author={Aguilera, Antonio and P{\'e}rez-Aguila, Ricardo},
-      year={2004},
-      publisher={V{\'a}clav Skala-UNION Agency}
+    @inproceedings{aguilera2004general,
+    author = {Aguilera, Antonio and P{\'{e}}rez-Aguila, Ricardo},
+    booktitle = {WSCG' 2004 - 12-th International Conference in Central Europe on Computer Graphics, Visualization and Computer Vision},
+    keywords = {4d visualization and animation,geometric reasoning,topological and geometrical interrogations},
+    pages = {227},
+    title = {{General n-dimensional rotations}},
+    url = {http://hdl.handle.net/11025/6178},
+    year = {2004}
     }
     """
     # TODO: Assert vectors are non-zero and non-parallel aka exterior

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -528,11 +528,11 @@ def _rotate(polyreg, i=None, j=None, u=None, v=None, theta=None, R=None):
             logger.info("rotate via indices and angle.")
             if i == j:
                 raise ValueError("Must provide two unique basis vectors.")
-            R = _Givens_rotation_matrix(i, j, theta, polyreg.dim)
+            R = givens_rotation_matrix(i, j, theta, polyreg.dim)
 
     elif u is not None and v is not None:  # theta is None
             logger.info("rotate via 2 vectors.")
-            R = _solve_rotation(u, v)
+            R = solve_rotation_ap(u, v)
 
     else:
         raise ValueError("R or (i and j and theta) or (u and v) "
@@ -560,7 +560,7 @@ def _rotate(polyreg, i=None, j=None, u=None, v=None, theta=None, R=None):
     return R
 
 
-def _Givens_rotation_matrix(i, j, theta, N):
+def givens_rotation_matrix(i, j, theta, N):
     """Return the Givens rotation matrix for an N-dimensional space."""
     R = np.identity(N)
     c = np.cos(theta)
@@ -572,7 +572,7 @@ def _Givens_rotation_matrix(i, j, theta, N):
     return R
 
 
-def _solve_rotation(u, v):
+def solve_rotation_ap(u, v):
     """Return the rotation matrix for the rotation in the plane defined by the
     vectors u and v across TWICE the angle between u and v.
 
@@ -600,7 +600,7 @@ def _solve_rotation(u, v):
     booktitle = {WSCG' 2004 - 12-th International Conference in Central Europe on Computer Graphics, Visualization and Computer Vision},
     keywords = {4d visualization and animation,geometric reasoning,topological and geometrical interrogations},
     pages = {227},
-    title = {{General n-dimensional rotations}},
+    title = {General n-dimensional rotations},
     url = {http://hdl.handle.net/11025/6178},
     year = {2004}
     }
@@ -626,7 +626,7 @@ def _solve_rotation(u, v):
         for c in range(N-1, r, -1):
             if uv[r, c] != 0:  # skip rotations when theta will be zero
                 theta = -np.arctan2(uv[r, c], uv[r, c-1])
-                Mk = _Givens_rotation_matrix(c, c-1, theta, N)
+                Mk = givens_rotation_matrix(c, c-1, theta, N)
                 logger.debug("in the {0},{1} plane rotate {2}".format(c, c-1,
                                                                       theta))
 
@@ -640,7 +640,7 @@ def _solve_rotation(u, v):
     theta = -2 * np.arctan2(uv[1, 1], uv[1, 0])
     logger.debug("computed {} degree rotation".format(180*theta/np.pi))
 
-    R = _Givens_rotation_matrix(1, 0, theta, N)
+    R = givens_rotation_matrix(1, 0, theta, N)
 
     # perform M rotations in reverse order
     M_inverse = M.T

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -528,13 +528,7 @@ def _rotate(polyreg, i=None, j=None, u=None, v=None, theta=None, R=None):
             logger.info("rotate via indices and angle.")
             if i == j:
                 raise ValueError("Must provide two unique basis vectors.")
-            R = np.identity(polyreg.dim)
-            c = np.cos(theta)
-            s = np.sin(theta)
-            R[i, i] = c
-            R[j, j] = c
-            R[i, j] = -s
-            R[j, i] = s
+            R = _Givens_rotation_matrix(i, j, theta, polyreg.dim)
 
     elif u is not None and v is not None:  # theta is None
             logger.info("rotate via 2 vectors.")
@@ -567,6 +561,18 @@ def _rotate(polyreg, i=None, j=None, u=None, v=None, theta=None, R=None):
     if polyreg._chebXc is not None:
         polyreg._chebXc = np.inner(polyreg._chebXc, R)
 
+    return R
+
+
+def _Givens_rotation_matrix(i, j, theta, N):
+    """Return the Givens rotation matrix for an N-dimensional space."""
+    R = np.identity(N)
+    c = np.cos(theta)
+    s = np.sin(theta)
+    R[i, i] = c
+    R[j, j] = c
+    R[i, j] = -s
+    R[j, i] = s
     return R
 
 

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -160,9 +160,9 @@ def solve_rotation_test_090(atol=1e-15):
     t1 = np.array([0, -1, 0, 0])
     t2 = np.array([0, 0, 0, 0])
 
-    assert_allclose(R @ e0, t0, atol=atol)
-    assert_allclose(R @ e1, t1, atol=atol)
-    assert_allclose(R @ e2, t2, atol=atol)
+    assert_allclose(R.dot(e0), t0, atol=atol)
+    assert_allclose(R.dot(e1), t1, atol=atol)
+    assert_allclose(R.dot(e2), t2, atol=atol)
 
 
 def solve_rotation_test_180(atol=1e-15):
@@ -178,9 +178,9 @@ def solve_rotation_test_180(atol=1e-15):
     t1 = np.array([0, 0, 1, 0])
     t2 = np.array([0, 0, 0, 0])
 
-    assert_allclose(R @ e0, t0, atol=atol)
-    assert_allclose(R @ e1, t1, atol=atol)
-    assert_allclose(R @ e2, t2, atol=atol)
+    assert_allclose(R.dot(e0), t0, atol=atol)
+    assert_allclose(R.dot(e1), t1, atol=atol)
+    assert_allclose(R.dot(e2), t2, atol=atol)
 
 
 def solve_rotation_test_270R(atol=1e-15):
@@ -196,9 +196,9 @@ def solve_rotation_test_270R(atol=1e-15):
     t1 = np.array([0, 1, 0, 0])
     t2 = np.array([0, 0, 0, 0])
 
-    assert_allclose(R @ e0, t0, atol=atol)
-    assert_allclose(R @ e1, t1, atol=atol)
-    assert_allclose(R @ e2, t2, atol=atol)
+    assert_allclose(R.dot(e0), t0, atol=atol)
+    assert_allclose(R.dot(e1), t1, atol=atol)
+    assert_allclose(R.dot(e2), t2, atol=atol)
 
 
 def solve_rotation_test_270L(atol=1e-15):
@@ -214,9 +214,9 @@ def solve_rotation_test_270L(atol=1e-15):
     t1 = np.array([0, -1, 0, 0])
     t2 = np.array([0, 0, 0, 0])
 
-    assert_allclose(R @ e0, t0, atol=atol)
-    assert_allclose(R @ e1, t1, atol=atol)
-    assert_allclose(R @ e2, t2, atol=atol)
+    assert_allclose(R.dot(e0), t0, atol=atol)
+    assert_allclose(R.dot(e1), t1, atol=atol)
+    assert_allclose(R.dot(e2), t2, atol=atol)
 
 
 if __name__ == '__main__':

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 from numpy.testing import assert_allclose
 import polytope as pc
-from polytope.polytope import _solve_rotation
+from polytope.polytope import solve_rotation_ap
 
 log = logging.getLogger('polytope.polytope')
 log.setLevel(logging.INFO)
@@ -150,7 +150,7 @@ def polytope_translation_test():
 def solve_rotation_test_090(atol=1e-15):
     g1 = np.array([0, 1, 1, 0])
     g2 = np.array([0, 1, 0, 0])
-    R = _solve_rotation(g1, g2)
+    R = solve_rotation_ap(g1, g2)
 
     e0 = np.array([0, 1, 1, 1])
     e1 = np.array([0, 0, -1, 0])
@@ -168,7 +168,7 @@ def solve_rotation_test_090(atol=1e-15):
 def solve_rotation_test_180(atol=1e-15):
     g1 = np.array([0, 1, 0, 0])
     g2 = np.array([0, 0, 1, 0])
-    R = _solve_rotation(g1, g2)
+    R = solve_rotation_ap(g1, g2)
 
     e0 = np.array([0, 1, 1, 1])
     e1 = np.array([0, 0, -1, 0])
@@ -186,7 +186,7 @@ def solve_rotation_test_180(atol=1e-15):
 def solve_rotation_test_270R(atol=1e-15):
     g1 = np.array([0, -1, 0, 0])
     g2 = np.array([0, 1, 1, 0])
-    R = _solve_rotation(g1, g2)
+    R = solve_rotation_ap(g1, g2)
 
     e0 = np.array([0, 1, 1, 1])
     e1 = np.array([0, 0, -1, 0])
@@ -204,7 +204,7 @@ def solve_rotation_test_270R(atol=1e-15):
 def solve_rotation_test_270L(atol=1e-15):
     g1 = np.array([0, -1, 0, 0])
     g2 = np.array([0, 1, -1, 0])
-    R = _solve_rotation(g1, g2)
+    R = solve_rotation_ap(g1, g2)
 
     e0 = np.array([0, 1, 1, 1])
     e1 = np.array([0, 0, -1, 0])

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 from numpy.testing import assert_allclose
 import polytope as pc
-from polytope.polytope import solve_rotation_ap
+from polytope.polytope import solve_rotation_ap, givens_rotation_matrix
 
 log = logging.getLogger('polytope.polytope')
 log.setLevel(logging.INFO)
@@ -219,5 +219,39 @@ def solve_rotation_test_270L(atol=1e-15):
     assert_allclose(R.dot(e2), t2, atol=atol)
 
 
+def givens_rotation_test_180(atol=1e-15):
+    R = givens_rotation_matrix(1, 2, np.pi, 4)
+
+    e0 = np.array([0, 1, 1, 1])
+    e1 = np.array([0, 0, -1, 0])
+    e2 = np.array([0, 0, 0, 0])
+
+    t0 = np.array([0, -1, -1, 1])
+    t1 = np.array([0, 0, 1, 0])
+    t2 = np.array([0, 0, 0, 0])
+
+    assert_allclose(R.dot(e0), t0, atol=atol)
+    assert_allclose(R.dot(e1), t1, atol=atol)
+    assert_allclose(R.dot(e2), t2, atol=atol)
+
+
+def givens_rotation_test_270L(atol=1e-15):
+    g1 = np.array([0, -1, 0, 0])
+    g2 = np.array([0, 1, -1, 0])
+    R = givens_rotation_matrix(1, 2, 3*np.pi/2, 4)
+
+    e0 = np.array([0, 1, 1, 1])
+    e1 = np.array([0, 0, -1, 0])
+    e2 = np.array([0, 0, 0, 0])
+
+    t0 = np.array([0, 1, -1, 1])
+    t1 = np.array([0, -1, 0, 0])
+    t2 = np.array([0, 0, 0, 0])
+
+    assert_allclose(R.dot(e0), t0, atol=atol)
+    assert_allclose(R.dot(e1), t1, atol=atol)
+    assert_allclose(R.dot(e2), t2, atol=atol)
+
+
 if __name__ == '__main__':
-    comparison_test()
+    pass

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 from numpy.testing import assert_allclose
 import polytope as pc
-
+from polytope.polytope import _solve_rotation
 
 log = logging.getLogger('polytope.polytope')
 log.setLevel(logging.INFO)
@@ -145,6 +145,79 @@ def polytope_translation_test():
     assert(not p == p1)
     p = p.translation([1, 0])
     assert(p == p1)
+
+
+def solve_rotation_test_090(atol=1e-15):
+    g1 = np.array([0, 1, 1, 0])
+    g2 = np.array([0, 1, 0, 0])
+    R = _solve_rotation(g1, g2)
+
+    e0 = np.array([0, 1, 1, 1])
+    e1 = np.array([0, 0, -1, 0])
+    e2 = np.array([0, 0, 0, 0])
+
+    t0 = np.array([0, 1, -1, 1])
+    t1 = np.array([0, -1, 0, 0])
+    t2 = np.array([0, 0, 0, 0])
+
+    assert_allclose(R @ e0, t0, atol=atol)
+    assert_allclose(R @ e1, t1, atol=atol)
+    assert_allclose(R @ e2, t2, atol=atol)
+
+
+def solve_rotation_test_180(atol=1e-15):
+    g1 = np.array([0, 1, 0, 0])
+    g2 = np.array([0, 0, 1, 0])
+    R = _solve_rotation(g1, g2)
+
+    e0 = np.array([0, 1, 1, 1])
+    e1 = np.array([0, 0, -1, 0])
+    e2 = np.array([0, 0, 0, 0])
+
+    t0 = np.array([0, -1, -1, 1])
+    t1 = np.array([0, 0, 1, 0])
+    t2 = np.array([0, 0, 0, 0])
+
+    assert_allclose(R @ e0, t0, atol=atol)
+    assert_allclose(R @ e1, t1, atol=atol)
+    assert_allclose(R @ e2, t2, atol=atol)
+
+
+def solve_rotation_test_270R(atol=1e-15):
+    g1 = np.array([0, -1, 0, 0])
+    g2 = np.array([0, 1, 1, 0])
+    R = _solve_rotation(g1, g2)
+
+    e0 = np.array([0, 1, 1, 1])
+    e1 = np.array([0, 0, -1, 0])
+    e2 = np.array([0, 0, 0, 0])
+
+    t0 = np.array([0, -1, 1, 1])
+    t1 = np.array([0, 1, 0, 0])
+    t2 = np.array([0, 0, 0, 0])
+
+    assert_allclose(R @ e0, t0, atol=atol)
+    assert_allclose(R @ e1, t1, atol=atol)
+    assert_allclose(R @ e2, t2, atol=atol)
+
+
+def solve_rotation_test_270L(atol=1e-15):
+    g1 = np.array([0, -1, 0, 0])
+    g2 = np.array([0, 1, -1, 0])
+    R = _solve_rotation(g1, g2)
+
+    e0 = np.array([0, 1, 1, 1])
+    e1 = np.array([0, 0, -1, 0])
+    e2 = np.array([0, 0, 0, 0])
+
+    t0 = np.array([0, 1, -1, 1])
+    t1 = np.array([0, -1, 0, 0])
+    t2 = np.array([0, 0, 0, 0])
+
+    assert_allclose(R @ e0, t0, atol=atol)
+    assert_allclose(R @ e1, t1, atol=atol)
+    assert_allclose(R @ e2, t2, atol=atol)
+
 
 if __name__ == '__main__':
     comparison_test()


### PR DESCRIPTION
Implements the two vector rotation specification that I've been talking about.

Two things that need to be addressed:

1. Where do .bib references go? I included one in my documentation.
2. Tests for this new method are applied directly instead of through the `Polytope` class. Is that acceptable?