### PR TITLE
ENH: __contains__ can check multiple points

### DIFF
--- a/polytope/__init__.py
+++ b/polytope/__init__.py
@@ -38,7 +38,7 @@ from .polytope import (
     is_empty, is_fulldim, is_convex, is_adjacent, is_subset,
     reduce, separate, box2poly, grid_region,
     cheby_ball, bounding_box, envelope, extreme, qhull,
-    is_inside, union, mldivide, intersect, volume, projection
+    is_inside, are_inside, union, mldivide, intersect, volume, projection
 )
 # from .plot import plot_partition, plot_transition_arrow
 from .prop2partition import Partition, MetricPartition, find_adjacent_regions

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -233,6 +233,8 @@ class Polytope(object):
         return np.all(test)
 
     def are_inside(self, points, abs_tol=ABS_TOL):
+        warnings.warn('polytope.are_inside is deprecated.'
+                      ' Use `polytope.contains` instead.', DeprecationWarning)
         test = self.A.dot(points) - self.b[:, np.newaxis] < abs_tol
         return np.all(test, axis=0)
 

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -517,14 +517,14 @@ def _rotate(polyreg, i=None, j=None, u=None, v=None, theta=None, R=None):
     """
     # determine the rotation matrix based on inputs
     if R is not None:
-        logger.info("rotate via predefined matrix.")
+        logger.debug("rotate: R=\n{}".format(R))
         assert i is None, i
         assert j is None, j
         assert theta is None, theta
         assert u is None, u
         assert v is None, v
     elif i is not None and j is not None and theta is not None:
-            logger.info("rotate via indices and angle.")
+            logger.debug("rotate: i={}, j={}, theta={}".format(i, j, theta))
             assert R is None, R
             assert u is None, u
             assert v is None, v
@@ -532,7 +532,7 @@ def _rotate(polyreg, i=None, j=None, u=None, v=None, theta=None, R=None):
                 raise ValueError("Must provide two unique basis vectors.")
             R = givens_rotation_matrix(i, j, theta, polyreg.dim)
     elif u is not None and v is not None:
-            logger.info("rotate via 2 vectors.")
+            logger.debug("rotate: u={}, v={}".format(u, v))
             assert R is None, R
             assert i is None, i
             assert j is None, j
@@ -613,29 +613,28 @@ def solve_rotation_ap(u, v):
         M[0, 0] = -1
         M[1, 1] = -1
         uv = M.dot(uv)
-    logger.debug('u = {u}'.format(u=uv[:, 0]))
-    logger.debug('v = {v}'.format(v=uv[:, 1]))
+    # logger.debug('u = {u}'.format(u=uv[:, 0]))
+    # logger.debug('v = {v}'.format(v=uv[:, 1]))
     # align uv plane with the basis01 plane and u with basis0.
     for c in range(0, 2):
         for r in range(N-1, c, -1):
             if uv[r, c] != 0:  # skip rotations when theta will be zero
                 theta = np.arctan2(uv[r, c], uv[r-1, c])
                 Mk = givens_rotation_matrix(r, r-1, theta, N)
-                logger.debug(
-                    "in the {r},{r1} plane rotate {theta}".format(
-                        r=r, r1=r-1, theta=theta))
+                # logger.debug("in the {r},{r1} plane rotate {theta}".format(
+                #              r=r, r1=r-1, theta=theta))
                 uv = Mk.dot(uv)
                 M = Mk.dot(M)
                 # logger.debug("u = {u}".format(u=uv[:, 0]))
                 # logger.debug("v = {v}".format(v=uv[:, 1]))
     # rotate u onto v
     theta = 2 * np.arctan2(uv[1, 1], uv[0, 1])
-    logger.debug("computed {} degree rotation".format(180*theta/np.pi))
+    logger.debug("solve_rotation_ap: {} degree rotation".format(180*theta/np.pi))
     R = givens_rotation_matrix(0, 1, theta, N)
     # perform M rotations in reverse order
     M_inverse = M.T
     R = M_inverse.dot(R.dot(M))
-    logger.debug("rotation matrix is\n{}".format(R))
+    # logger.debug("solve_rotation_ap: R=\n{}".format(R))
     return R
 
 

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -201,31 +201,12 @@ class Polytope(object):
         P.fulldim = self.fulldim
         return P
 
-    def contains(self, point, abs_tol=ABS_TOL):
-        """Return True if polytope contains points.
-
-        @type point: array_like, 1d array, or 2d array (of column vectors)
-
-        @rtype: bool, 1d array
-
-        See Also
-        ========
-        L{is_inside}
-        """
-        if not isinstance(point, np.ndarray):
-            point = np.array(point)
-        if point.ndim == 1:
-            point.shape = (point.size, 1)
-        assert point.shape[0] == self.dim, "points should be column vectors"
-        test = self.A.dot(point) - self.b.reshape((self.b.size, 1)) < abs_tol
-        return np.all(test, axis=0)
-
     def __contains__(self, point, abs_tol=ABS_TOL):
-        """Return True if polytope contains point.
+        """Return True if polytope contains (<) point.
 
         See Also
         ========
-        L{is_inside}, L{Polytope.contains}
+        L{is_inside}, L{are_inside}
         """
         if not isinstance(point, np.ndarray):
             point = np.array(point)
@@ -233,8 +214,9 @@ class Polytope(object):
         return np.all(test)
 
     def are_inside(self, points, abs_tol=ABS_TOL):
-        warnings.warn('polytope.are_inside is deprecated.'
-                      ' Use `polytope.contains` instead.', DeprecationWarning)
+        warnings.warn('Polytope.are_inside() is deprecated. Use the module'
+                      ' level are_inside(polyreg) instead.',
+                      DeprecationWarning)
         test = self.A.dot(points) - self.b[:, np.newaxis] < abs_tol
         return np.all(test, axis=0)
 
@@ -716,34 +698,12 @@ class Region(object):
     def __len__(self):
         return len(self.list_poly)
 
-    def contains(self, point, abs_tol=ABS_TOL):
-        """Return True if Region contains point.
-
-        @type point: array_like, 1d array, or 2d array (of column vectors)
-
-        @rtype: bool, 1d array
-
-        See Also
-        ========
-        L{is_inside}
-        """
-        if not isinstance(point, np.ndarray):
-            point = np.array(point)
-        if point.ndim == 1:
-            return self.__contains__(point, abs_tol=abs_tol)
-        else:
-            contained = np.full(point.shape[1], False, dtype=bool)
-            for poly in self.list_poly:
-                contained = np.logical_or(poly.contains(point, abs_tol),
-                                          contained)
-            return contained
-
     def __contains__(self, point, abs_tol=ABS_TOL):
-        """Return True if Region contains point.
+        """Return True if Region contains (<) point.
 
         See Also
         ========
-        L{is_inside}, L{Region.contains}
+        L{is_inside}, L{are_inside}
         """
         if not isinstance(point, np.ndarray):
             point = np.array(point)
@@ -1013,14 +973,49 @@ def is_convex(reg, abs_tol=ABS_TOL):
 
 
 def is_inside(polyreg, point, abs_tol=ABS_TOL):
-    """Checks if point satisfies all the inequalities of polyreg.
+    """Check if point satisfies all the inequalities (<) of polyreg.
+
+    point may be any shape because it is flattened.
+
+    @param polyreg: L{Polytope} or L{Region}
+    @type point: tuple, or array
+
+    @rtype: bool
+
+    See Also
+    ========
+    L{Polytope.__contains__}, L{Region.__contains__}, L{are_inside}
+    """
+    return polyreg.__contains__(point, abs_tol)
+
+
+def are_inside(polyreg, points, abs_tol=ABS_TOL):
+    """Check whether points satisfy all the inequalities (<) of polyreg.
 
     @param polyreg: L{Polytope} or L{Region}
     @type point: tuple, 1d array, or 2d array (of column vectors)
 
     @rtype: bool, 1d array
+
+    See Also
+    ========
+    L{is_inside}
     """
-    return polyreg.contains(point, abs_tol)
+    if not isinstance(points, np.ndarray):
+        points = np.array(points)
+    if points.ndim == 1:
+        points.shape = (points.size, 1)
+    assert points.shape[0] == polyreg.dim, "points should be column vectors"
+    if isinstance(polyreg, Polytope):
+        test = polyreg.A.dot(points) - polyreg.b.reshape((polyreg.b.size, 1)) \
+               < abs_tol
+        return np.all(test, axis=0)
+    else:  # isinstance(polyreg, Region)
+        contained = np.full(points.shape[1], False, dtype=bool)
+        for poly in polyreg.list_poly:
+            contained = np.logical_or(poly.contains(points, abs_tol),
+                                      contained)
+        return contained
 
 
 def is_subset(small, big, abs_tol=ABS_TOL):
@@ -2255,7 +2250,7 @@ def grid_region(polyreg, res=None):
         linspaces.append(r)
     points = np.meshgrid(*linspaces)
     x = np.vstack(map(np.ravel, points))
-    x = x[:, polyreg.are_inside(x)]
+    x = x[:, are_inside(polyreg, x)]
     return (x, res)
 
 

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -216,7 +216,7 @@ class Polytope(object):
             point = np.array(point)
         if point.ndim == 1:
             point.shape = (point.size, 1)
-        assert point.shape[0] == self.dim, "points should be col vectors"
+        assert point.shape[0] == self.dim, "points should be column vectors"
         test = self.A.dot(point) - self.b.reshape((self.b.size, 1)) < abs_tol
         return np.all(test, axis=0)
 

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -3,7 +3,7 @@
 import logging
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 import polytope as pc
 from polytope.polytope import solve_rotation_ap, givens_rotation_matrix
 
@@ -198,6 +198,19 @@ class operations_test(object):
         assert pc.is_fulldim(p4)
         assert pc.is_fulldim(p5)
 
+    def polytope_contains_test(self):
+        p = pc.Polytope(self.A, self.b)
+
+        point_i = [0.1, 0.3]
+        point_o = [2, 0]
+        assert point_i in p
+        assert point_o not in p
+
+        many_points_i = np.random.random((2, 8))
+        many_points_0 = np.random.random((2, 8)) - np.array([[0], [1]])
+        many_points = np.concatenate([many_points_0, many_points_i], axis=1)
+        truth = np.array([False] * 8 + [True] * 8, dtype=bool)
+        assert_array_equal(pc.is_inside(p, many_points), truth)
 
 
 def solve_rotation_test_090(atol=1e-15):

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -210,7 +210,7 @@ class operations_test(object):
         many_points_0 = np.random.random((2, 8)) - np.array([[0], [1]])
         many_points = np.concatenate([many_points_0, many_points_i], axis=1)
         truth = np.array([False] * 8 + [True] * 8, dtype=bool)
-        assert_array_equal(pc.is_inside(p, many_points), truth)
+        assert_array_equal(pc.are_inside(p, many_points), truth)
 
 
 def solve_rotation_test_090(atol=1e-15):


### PR DESCRIPTION
If you want to check whether many points are inside a polytope,
looping over each point and using `in` is very slow compared to
testing all the points simultaneously. This commit allows the
user to specify an `np.ndarray` of column vectors to check
simultaneously. The return value is then an array of bools.
In order to use this feature, you have to call `__contains__` directly
instead of using `in`.