### PR TITLE
Extract as new module `solvers`, and support MOSEK

### DIFF
--- a/polytope/esp.py
+++ b/polytope/esp.py
@@ -106,10 +106,10 @@ def esp(CC, DD, bb, centered=False, abs_tol=1e-10, verbose=0):
     P = {[C D]x <= b} where C is M x D and D is M x K is
     defined as proj(P) = {x in R^d | exist y in R^k s.t Cx + Dy < b}
     """
-    if solvers.default_solver != 'glpk':
+    if 'glpk' in solvers.installed_solvers:
         raise Exception(
             "projection_esp error:"
-            " Equality set projection requires cvxopt to run.")
+            " Equality set projection requires `cvxopt.glpk` to run.")
     # Remove zero columns and rows
     nonzerorows = np.nonzero(
         np.sum(np.abs(np.hstack([CC, DD])), axis=1) > abs_tol)[0]

--- a/polytope/esp.py
+++ b/polytope/esp.py
@@ -106,7 +106,7 @@ def esp(CC, DD, bb, centered=False, abs_tol=1e-10, verbose=0):
     P = {[C D]x <= b} where C is M x D and D is M x K is
     defined as proj(P) = {x in R^d | exist y in R^k s.t Cx + Dy < b}
     """
-    if solvers.lp_solver != 'glpk':
+    if solvers.default_solver != 'glpk':
         raise Exception(
             "projection_esp error:"
             " Equality set projection requires cvxopt to run.")

--- a/polytope/esp.py
+++ b/polytope/esp.py
@@ -117,6 +117,10 @@ def esp(CC, DD, bb, centered=False, abs_tol=1e-10, verbose=0):
     P = {[C D]x <= b} where C is M x D and D is M x K is
     defined as proj(P) = {x in R^d | exist y in R^k s.t Cx + Dy < b}
     """
+    if lp_solver != 'glpk':
+        raise Exception(
+            "projection_esp error:"
+            " Equality set projection requires cvxopt to run.")
     # Remove zero columns and rows
     nonzerorows = np.nonzero(
         np.sum(np.abs(np.hstack([CC, DD])), axis=1) > abs_tol)[0]

--- a/polytope/esp.py
+++ b/polytope/esp.py
@@ -409,7 +409,7 @@ def ridge(C, D, b, E, af, bf, abs_tol=1e-7, verbose=0):
                 Ar = np.vstack([af, S[i, :]])
                 A = np.hstack([Al, Ar])
                 bb = np.hstack([bf, t[i]])
-                sol = solvers._solve_lp_using_glpk(
+                sol = solvers._solve_lp_using_cvxopt(
                     c, G, h, A=A, b=bb)
                 if sol['status'] == 'optimal':
                     tau = sol['x'][0]
@@ -459,7 +459,7 @@ def adjacent(C, D, b, rid_fac, abs_tol=1e-7):
     G = np.hstack([C_er, D_er])
     h = b_er
     A = np.hstack([af, np.zeros(k)])
-    sol = solvers._solve_lp_using_glpk(
+    sol = solvers._solve_lp_using_cvxopt(
         c, G, h, A=A.T, b=bf * (1 - 0.01))
     if sol['status'] != "optimal":
         print(G)
@@ -609,7 +609,7 @@ def is_dual_degenerate(c, G, h, A, b, x_opt, z_opt, abs_tol=1e-7):
             be = np.zeros(Ae.shape[0])
             Ai = - DL
             bi = np.zeros(nL)
-            sol = solvers._solve_lp_using_glpk(
+            sol = solvers._solve_lp_using_cvxopt(
                 c= - np.sum(DL, axis=0), G=Ai,
                 h=bi, A=Ae, b=be)
             if sol['status'] == "dual infeasible":
@@ -640,7 +640,7 @@ def unique_equalityset(C, D, b, af, bf, abs_tol=1e-7, verbose=0):
     for i in range(A.shape[0]):
         A_i = np.array(A[i, :])
         b_i = b[i]
-        sol = solvers._solve_lp_using_glpk(
+        sol = solvers._solve_lp_using_cvxopt(
             c=A_i, G=A, h=b,
             A=a.T, b=bf)
         if sol['status'] != "optimal":

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -68,14 +68,11 @@ import warnings
 import numpy as np
 
 from polytope.solvers import lpsolve
+from polytope.esp import esp
 from polytope.quickhull import quickhull
 
 
 logger = logging.getLogger(__name__)
-try:
-    from polytope.esp import esp
-except ImportError:
-    esp = None
 try:
     xrange
 except NameError:
@@ -1950,9 +1947,6 @@ def projection_esp(poly1, keep_dim, del_dim):
 
     CAUTION: Very buggy.
     """
-    if lp_solver != 'glpk':
-        raise Exception("projection_esp error:"
-                        " Equality set projection requires cvxopt to run.")
     C = poly1.A[:, keep_dim]
     D = poly1.A[:, del_dim]
     if not is_fulldim(poly1):

--- a/polytope/solvers.py
+++ b/polytope/solvers.py
@@ -1,0 +1,119 @@
+"""Interface to linear programming solvers.
+
+By default, for linear programming the `polytope` package selects
+the fastest solver that it finds installed. You can change this
+default by setting the variable `lp_solver` in the module
+`_solvers`. For example:
+
+```python
+from polytope import _solvers
+
+_solvers.lp_solver = 'scipy'
+```
+
+Choose an installed solver to avoid errors.
+"""
+# Copyright (c) 2011-2017 by California Institute of Technology
+# All rights reserved. Licensed under BSD-3.
+#
+from __future__ import absolute_import
+import logging
+
+import numpy as np
+from scipy import optimize
+
+
+logger = logging.getLogger(__name__)
+try:
+    from cvxopt import matrix, solvers
+    import cvxopt.glpk
+    lp_solver = 'glpk'
+    # Hide optimizer output
+    solvers.options['show_progress'] = False
+    solvers.options['glpk'] = dict(msg_lev='GLP_MSG_OFF')
+    logger.info('will use `cvxopt.glpk` solver')
+except ImportError:
+    lp_solver = 'scipy'
+    logger.warn(
+        '`polytope` failed to import `cvxopt.glpk`.\n'
+        'Will use `scipy.optimize.linprog`.')
+
+
+
+def lpsolve(c, G, h, solver=None):
+    """Try to solve linear program with `cvxopt.glpk`, else `scipy`.
+
+    Solvers:
+        - `cvxopt.glpk`: identified by `'glpk'`
+        - `scipy.optimize.linprog`: identified by `'scipy'`
+
+    @param solver:
+        - `in {'glpk', 'scipy'}`
+        - `None`: use the fastest installed solver,
+          as follows:
+
+            1. use GLPK if installed
+            2. otherwise use SciPy
+
+        You can change the default choice of solver by setting
+        the module variable `lp_solver`. See the module's
+        docstring for an example.
+
+    @return: solution with status as in `scipy.optimize.linprog`
+    @rtype: `dict(status=int, x=argmin, fun=min_value)`
+    """
+    if solver is None:
+        solver = lp_solver  # choose fastest installed solver
+    if solver == 'glpk' and lp_solver != 'glpk':
+        raise ImportError('GLPK requested but failed to import.')
+    if solver == 'glpk':
+        result = _solve_lp_using_glpk(c, G, h)
+    elif solver == 'scipy':
+        result = _solve_lp_using_scipy(c, G, h)
+    else:
+        raise Exception(
+            'unknown LP solver "{s}".'.format(s=lp_solver))
+    return result
+
+
+def _solve_lp_using_glpk(c, G, h):
+    """Attempt linear optimization using `cvxopt.glpk`."""
+    assert lp_solver == 'glpk', 'GLPK failed to import'
+    sol = solvers.lp(
+        c=matrix(c), G=matrix(G), h=matrix(h),
+        A=None, b=None, solver='glpk')
+    result = dict()
+    if sol['status'] == 'optimal':
+        result['status'] = 0
+    elif sol['status'] == 'primal infeasible':
+        result['status'] = 2
+    elif sol['status'] == 'dual infeasible':
+        result['status'] = 3
+    elif sol['status'] == 'unknown':
+        result['status'] = 4
+    else:
+        raise ValueError((
+            '`cvxopt.solvers.lp` returned unexpected '
+            'status value: {v}').format(v=sol['status']))
+    # `cvxopt.solvers.lp` returns an array of shape `(2, 1)`
+    # squeeze only the second dimension, to obtain a 1-D array
+    # thus match what `scipy.optimize.linprog` returns.
+    x = sol['x']
+    if x is not None:
+        assert x.typecode == 'd', x.typecode
+        result['x'] = np.fromiter(x, dtype=np.double)
+    else:
+        result['x'] = None
+    result['fun'] = sol['primal objective']
+    return result
+
+
+def _solve_lp_using_scipy(c, G, h):
+    """Attempt linear optimization using `scipy.optimize.linprog`."""
+    sol = optimize.linprog(
+        c, G, np.transpose(h),
+        None, None, bounds=(None, None))
+    return dict(
+        status=sol.status,
+        x=sol.x,
+        fun=sol.fun)

--- a/polytope/solvers.py
+++ b/polytope/solvers.py
@@ -76,12 +76,16 @@ def lpsolve(c, G, h, solver=None):
     return result
 
 
-def _solve_lp_using_glpk(c, G, h):
+def _solve_lp_using_glpk(c, G, h, A=None, b=None):
     """Attempt linear optimization using `cvxopt.glpk`."""
     assert lp_solver == 'glpk', 'GLPK failed to import'
+    if A is not None:
+        A = matrix(A)
+    if b is not None:
+        b = matrix(b)
     sol = solvers.lp(
         c=matrix(c), G=matrix(G), h=matrix(h),
-        A=None, b=None, solver='glpk')
+        A=A, b=b, solver='glpk')
     result = dict()
     if sol['status'] == 'optimal':
         result['status'] = 0

--- a/polytope/solvers.py
+++ b/polytope/solvers.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2011-2017 by California Institute of Technology
+# All rights reserved. Licensed under 3-clause BSD.
 """Interface to linear programming solvers.
 
 The `polytope` package selects the default solver as follows:
@@ -21,9 +23,6 @@ print(solvers.installed_solvers)
 
 Choose an installed solver to avoid errors.
 """
-# Copyright (c) 2011-2017 by California Institute of Technology
-# All rights reserved. Licensed under BSD-3.
-#
 from __future__ import absolute_import
 import logging
 

--- a/polytope/solvers.py
+++ b/polytope/solvers.py
@@ -27,13 +27,13 @@ logger = logging.getLogger(__name__)
 try:
     from cvxopt import matrix, solvers
     import cvxopt.glpk
-    lp_solver = 'glpk'
+    default_solver = 'glpk'
     # Hide optimizer output
     solvers.options['show_progress'] = False
     solvers.options['glpk'] = dict(msg_lev='GLP_MSG_OFF')
     logger.info('will use `cvxopt.glpk` solver')
 except ImportError:
-    lp_solver = 'scipy'
+    default_solver = 'scipy'
     logger.warn(
         '`polytope` failed to import `cvxopt.glpk`.\n'
         'Will use `scipy.optimize.linprog`.')
@@ -56,15 +56,15 @@ def lpsolve(c, G, h, solver=None):
             2. otherwise use SciPy
 
         You can change the default choice of solver by setting
-        the module variable `lp_solver`. See the module's
+        the module variable `default_solver`. See the module's
         docstring for an example.
 
     @return: solution with status as in `scipy.optimize.linprog`
     @rtype: `dict(status=int, x=argmin, fun=min_value)`
     """
     if solver is None:
-        solver = lp_solver  # choose fastest installed solver
-    if solver == 'glpk' and lp_solver != 'glpk':
+        solver = default_solver
+    if solver == 'glpk' and default_solver != 'glpk':
         raise ImportError('GLPK requested but failed to import.')
     if solver == 'glpk':
         result = _solve_lp_using_glpk(c, G, h)
@@ -72,13 +72,13 @@ def lpsolve(c, G, h, solver=None):
         result = _solve_lp_using_scipy(c, G, h)
     else:
         raise Exception(
-            'unknown LP solver "{s}".'.format(s=lp_solver))
+            'unknown LP solver "{s}".'.format(s=default_solver))
     return result
 
 
 def _solve_lp_using_glpk(c, G, h, A=None, b=None):
     """Attempt linear optimization using `cvxopt.glpk`."""
-    assert lp_solver == 'glpk', 'GLPK failed to import'
+    assert default_solver == 'glpk', 'GLPK failed to import'
     if A is not None:
         A = matrix(A)
     if b is not None:

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -439,7 +439,7 @@ def test_lpsolve_solver_selection_glpk_absent():
             'Skipping GLPK failure test, '
             'because GLPK is present.')
         return
-    with nt.assert_raises(ImportError):
+    with nt.assert_raises(RuntimeError):
         solvers.lpsolve(c, A, b, solver='glpk')
 
 
@@ -457,8 +457,12 @@ def is_glpk_present():
     """Return `True` if `cvxopt.glpk` imports."""
     try:
         import cvxopt.glpk
+        assert 'glpk' in solvers.installed_solvers, (
+            solvers.installed_solvers)
         return True
     except ImportError:
+        assert 'glpk' not in solvers.installed_solvers, (
+            solvers.installed_solvers)
         return False
 
 

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -10,7 +10,7 @@ import scipy.optimize
 
 import polytope as pc
 from polytope.polytope import solve_rotation_ap, givens_rotation_matrix
-from polytope import polytope as ptm
+from polytope import solvers
 
 log = logging.getLogger('polytope.polytope')
 log.setLevel(logging.INFO)
@@ -385,14 +385,14 @@ def test_lpsolve():
     c = np.array([1, 1], dtype=float)
     A = np.array([[-1, 0], [0, -1]], dtype=float)
     b = np.array([1, 1], dtype=float)
-    res = ptm.lpsolve(c, A, b)
+    res = solvers.lpsolve(c, A, b)
     x = res['x']
     assert x.ndim == 1, x.ndim
     assert x.shape == (2,), x.shape
     #
     # 1-D example
     c, A, b = example_1d()
-    res = ptm.lpsolve(c, A, b)
+    res = solvers.lpsolve(c, A, b)
     x = res['x']
     assert x.ndim == 1, x.ndim
     assert x.shape == (1,), x.shape
@@ -410,9 +410,9 @@ def test_lpsolve_solver_selection_scipy():
     c, A, b = example_1d()
     r_ = np.array([-1.0])
     # call directly to isolate from selection within `lpsolve`
-    r = ptm._solve_lp_using_scipy(c, A, b)
+    r = solvers._solve_lp_using_scipy(c, A, b)
     assert r['x'] == r_, r['x']
-    r = ptm.lpsolve(c, A, b, solver='scipy')
+    r = solvers.lpsolve(c, A, b, solver='scipy')
     assert r['x'] == r_, r['x']
 
 
@@ -426,7 +426,7 @@ def test_lpsolve_solver_selection_glpk_present():
             'because GLPK failed to import, '
             'so assume not installed.')
         return
-    r = ptm.lpsolve(c, A, b, solver='glpk')
+    r = solvers.lpsolve(c, A, b, solver='glpk')
     assert r['x'] == np.array([-1.0]), r['x']
 
 
@@ -440,7 +440,7 @@ def test_lpsolve_solver_selection_glpk_absent():
             'because GLPK is present.')
         return
     with nt.assert_raises(ImportError):
-        ptm.lpsolve(c, A, b, solver='glpk')
+        solvers.lpsolve(c, A, b, solver='glpk')
 
 
 def is_glpk_present():

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -443,6 +443,16 @@ def test_lpsolve_solver_selection_glpk_absent():
         solvers.lpsolve(c, A, b, solver='glpk')
 
 
+def test_request_glpk_after_changing_default_to_scipy():
+    c, A, b = example_1d()
+    have_glpk = is_glpk_present()
+    if not have_glpk:
+        return
+    assert solvers.lp_solver != 'scipy'
+    solvers.lp_solver = 'scipy'
+    solvers.lpsolve(c, A, b, solver='glpk')
+
+
 def is_glpk_present():
     """Return `True` if `cvxopt.glpk` imports."""
     try:

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -378,7 +378,7 @@ def givens_rotation_test_270L(atol=1e-15):
 def test_lpsolve():
     # Ensure same API for both `scipy` and `cvxopt`.
     # Ensured by the different testing configurations.
-    # Could change `polytope.polytope.lp_solver` to
+    # Could change `polytope.polytope.default_solver` to
     # achieve the same result, when `cvxopt.glpk` is present.
     #
     # 2-D example
@@ -448,8 +448,8 @@ def test_request_glpk_after_changing_default_to_scipy():
     have_glpk = is_glpk_present()
     if not have_glpk:
         return
-    assert solvers.lp_solver != 'scipy'
-    solvers.lp_solver = 'scipy'
+    assert solvers.default_solver != 'scipy'
+    solvers.default_solver = 'scipy'
     solvers.lpsolve(c, A, b, solver='glpk')
 
 


### PR DESCRIPTION
Addresses:

1. A bug described at: https://github.com/tulip-control/polytope/issues/17#issuecomment-335316011.
2. Separation of concerns, by hiding implementation details of interfaces in their own module, called `solvers`.
3. Merges the branch `mosek`.