### PR TITLE
workaround bug in cvxopt v1.2.0

### DIFF
--- a/polytope/solvers.py
+++ b/polytope/solvers.py
@@ -40,7 +40,7 @@ try:
     installed_solvers.add('glpk')
     # Hide optimizer output
     cvx.solvers.options['show_progress'] = False
-    cvx.solvers.options['glpk'] = dict(msg_lev='GLP_MSG_OFF')
+    cvx.glpk.options['msg_lev'] = 'GLP_MSG_OFF'
 except ImportError:
     logger.warn(
         '`polytope` failed to import `cvxopt.glpk`.')


### PR DESCRIPTION
This pull request addresses issue #51.

The only commit here is the change first proposed at
https://github.com/tulip-control/polytope/issues/51#issuecomment-401656869

The bug in version 1.2.0 of cvxopt is reported upstream at
https://github.com/cvxopt/cvxopt/issues/120

N.B., the patch from this PR will continue to be correct after upstream fixes the bug and makes a new release, assuming there are not new, API-breaking changes in that release.