### PR TITLE
Customizable plotting + removed deprecated logger.warn calls

### DIFF
--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -403,8 +403,15 @@ class Polytope(object):
     def plot(self, ax=None, color=None, hatch=None, alpha=1.0, linestyle=None, linewidth=None, edgecolor=None):
         if self.dim != 2:
             raise Exception("Cannot plot polytopes of dimension larger than 2")
+        
+        # Setting default values for plotting
+        linestyle = linestyle or "dashed"
+        linewidth = linewidth or 3
+        edgecolor = edgecolor or "black"
+        
         ax = _newax(ax)
         if not is_fulldim(self):
+            logger.error("Cannot plot empty polytope")
             return None
         if color is None:
             color = np.random.rand(3)
@@ -854,8 +861,7 @@ class Region(object):
             self.bbox = bounding_box(self)
         return self.bbox
 
-    def plot(self, ax=None, color=None,
-             hatch=None, alpha=1.0):
+    def plot(self, ax=None, color=None, hatch=None, alpha=1.0, linestyle=None, linewidth=None, edgecolor=None):
         """Plot a `polytope` on axes `ax`."""
         # TODO optional arg for text label
         if self.dim != 2:
@@ -868,7 +874,8 @@ class Region(object):
             color = np.random.rand(3)
         for poly2 in self.list_poly:
             # TODO hatched polytopes in same region
-            poly2.plot(ax, color=color, hatch=hatch, alpha=alpha)
+            poly2.plot(ax, color=color, hatch=hatch, alpha=alpha, linestyle=linestyle, linewidth=linewidth,
+                       edgecolor=edgecolor)
         return ax
 
     def text(self, txt, ax=None, color='black'):

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -400,20 +400,18 @@ class Polytope(object):
             self.bbox = bounding_box(self)
         return self.bbox
 
-    def plot(self, ax=None, color=None,
-             hatch=None, alpha=1.0):
+    def plot(self, ax=None, color=None, hatch=None, alpha=1.0, linestyle=None, linewidth=None, edgecolor=None):
         if self.dim != 2:
             raise Exception("Cannot plot polytopes of dimension larger than 2")
         ax = _newax(ax)
         if not is_fulldim(self):
-            logger.error("Cannot plot empty polytope")
             return None
         if color is None:
             color = np.random.rand(3)
         poly = _get_patch(
             self, facecolor=color, hatch=hatch,
-            alpha=alpha, linestyle='dashed', linewidth=3,
-            edgecolor='black')
+            alpha=alpha, linestyle=linestyle, linewidth=linewidth,
+            edgecolor=edgecolor)
         ax.add_patch(poly)
         return ax
 

--- a/polytope/solvers.py
+++ b/polytope/solvers.py
@@ -42,7 +42,7 @@ try:
     cvx.solvers.options['show_progress'] = False
     cvx.glpk.options['msg_lev'] = 'GLP_MSG_OFF'
 except ImportError:
-    logger.warn(
+    logger.warning(
         '`polytope` failed to import `cvxopt.glpk`.')
 try:
     import mosek
@@ -56,7 +56,7 @@ if 'glpk' in installed_solvers:
     default_solver = 'glpk'
 elif 'scipy' in installed_solvers:
     default_solver = 'scipy'
-    logger.warn('will use `scipy.optimize.linprog`')
+    logger.warning('will use `scipy.optimize.linprog`')
 else:
     raise ValueError(
         "`installed_solvers` wasn't empty above?")


### PR DESCRIPTION
I am using polytope to plot polytopes and the default settings were not ideal for me. I changed the `Polytope.plot` function to accept additional parameters.
Moreover, `logger.warn` has been deprecated so I changed those calls to `logger.warning` 