### PR TITLE
Bug fix in projection_interhull()

### DIFF
--- a/polytope/plot.py
+++ b/polytope/plot.py
@@ -116,7 +116,7 @@ def plot_partition(
         # single polytope or region ?
         reg.plot(color=col, ax=ax)
         if plot_numbers:
-            reg.text(str(i), ax, color='red')
+            reg.text(str(i), ax, color='black')
     # not show trans ?
     if trans is 'none':
         mpl.pyplot.show()

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -1933,7 +1933,8 @@ def projection_iterhull(poly1, new_dim, max_iter=1000,
             logger.debug("Checking if new points are inside convex hull")
             OK = 1
             for i in xrange(np.shape(Vert)[0]):
-                if not P1.contains([Vert[i, new_dim]], abs_tol=1e-5):
+                if not P1.contains(np.transpose([Vert[i, new_dim]]),
+                                   abs_tol=1e-5):
                     # If all new points are inside
                     # old polytope -> Finished
                     OK = 0

--- a/polytope/solvers.py
+++ b/polytope/solvers.py
@@ -90,7 +90,7 @@ def lpsolve(c, G, h, solver=None):
         result = _solve_lp_using_scipy(c, G, h)
     else:
         raise Exception(
-            'unknown LP solver "{s}".'.format(s=default_solver))
+            'unknown LP solver "{s}".'.format(s=solver))
     return result
 
 


### PR DESCRIPTION
There was a missing call to `np.transpose` in `projection_interhull` that was generating errors in TuLiP in some configurations.  Fixed in this PR, along with a small error in an `lpsolve` error message (also uncovered while debugging TuLiP).

This PR should really have a unit test that demonstrates the error in `projection_interhull` and its fix, but I need this for a fix in TuLiP and so leaving that until a later PR.
