### PR TITLE
BUG: call method `contains` from `is_inside`

### DIFF
--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -964,12 +964,18 @@ def is_convex(reg, abs_tol=ABS_TOL):
 
 
 def is_inside(polyreg, point, abs_tol=ABS_TOL):
-    """Return `point in polyreg`."""
+    """Return `point in polyreg`.
+
+    @type point: `collections.abc.Sequence` or `numpy.ndarray`
+    @rtype: bool
+    """
     warnings.warn(
         'Write `point in polyreg` instead of '
         'calling this function.',
         DeprecationWarning)
-    return polyreg.__contains__(point, abs_tol)
+    if not isinstance(point, np.ndarray):
+        point = np.array(point)
+    return polyreg.contains(point[:, np.newaxis], abs_tol)[0]
 
 
 def is_subset(small, big, abs_tol=ABS_TOL):

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -268,6 +268,26 @@ class operations_test(object):
             [[False, False, True, False, False]], dtype=bool)
         assert np.all(c == c_), c
 
+    def is_inside_test(self):
+        box = [[0.0, 1.0], [0.0, 2.0]]
+        p = pc.Polytope.from_box(box)
+        point = np.array([0.0, 1.0])
+        abs_tol = 0.01
+        assert pc.is_inside(p, point)
+        assert pc.is_inside(p, point, abs_tol)
+        region = pc.Region([p])
+        assert pc.is_inside(region, point)
+        assert pc.is_inside(region, point, abs_tol)
+        point = np.array([2.0, 0.0])
+        assert not pc.is_inside(p, point)
+        assert not pc.is_inside(p, point, abs_tol)
+        region = pc.Region([p])
+        assert not pc.is_inside(region, point)
+        assert not pc.is_inside(region, point, abs_tol)
+        abs_tol = 1.2
+        assert pc.is_inside(p, point, abs_tol)
+        assert pc.is_inside(region, point, abs_tol)
+
 
 def solve_rotation_test_090(atol=1e-15):
     g1 = np.array([0, 1, 1, 0])


### PR DESCRIPTION
The function `polytope.polytope.is_inside` was outdated after a change (6d8380a7f2bad099c3c6abd8fc0a1229ef2adb1b) to the methods`polytope.polytope.Polytope.__contains__` and `polytope.polytope.Region.__contains__` that removed the argument for absolute tolerance. This change updates the function `is_inside` to call the methods `Polytope.contains` and `Region.contains` that take this argument.