### PR TITLE
Region diff fix

### DIFF
--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2069,7 +2069,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                 ])
                 Adummy = A[auxINDICES, :]
                 bdummy = B[auxINDICES]
-                R, xopt = cheby_ball(Polytope(Adummy, bdummy))
+                R, _ = cheby_ball(Polytope(Adummy, bdummy))
                 if R > abs_tol:
                     level = j
                     counter[level] = 1
@@ -2124,7 +2124,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                             logger.debug('returning res from 2nd point')
                         return res
         test_poly = Polytope(A[INDICES, :], B[INDICES])
-        rc, xc = cheby_ball(test_poly)
+        rc, _ = cheby_ball(test_poly)
         if rc > abs_tol:
             if level == N - 1:
                 res = union(res, reduce(test_poly), False)

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2076,23 +2076,17 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                     INDICES = np.hstack([INDICES, beg_mi[level] + M])
                     break
             if R < abs_tol:
-                level -= 1
+                # Since no polytope will remove anything, the current set of hyperplanes must be in the result
                 res = union(res, reduce(Polytope(A[INDICES, :], B[INDICES])), False)
-                nzcount = np.nonzero(counter)[0]
-                for jj in xrange(len(nzcount) - 1, -1, -1):
-                    if counter[level] <= mi[level]:
-                        INDICES[-1] -= M
-                        INDICES = np.hstack([
-                            INDICES,
-                            beg_mi[level] + counter[level] + M
-                        ])
-                        break
-                    else:
-                        counter[level] = 0
-                        INDICES = INDICES[0:m + np.sum(counter)]
-                        if level == -1:
-                            logger.debug('returning res from 1st point')
-                            return res
+                # None of the remaining polytopes removes anything
+                # Indicate that we are done at this level
+                counter[level] = mi[level]
+                # Add the polytope to the indices to get an empty intersection
+                # This will force the algorithm to pop out of this level and move on
+                INDICES = np.hstack([
+                    INDICES,
+                    range(beg_mi[level], beg_mi[level] + mi[level])
+                ])
         else:
             if save:
                 logger.debug('counter[level] > 0')

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -1971,6 +1971,10 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                 save=False):
     """Subtract a region from a polytope
 
+    For a discription of the algorithm, see algorithm 2 in:
+    Mato Baotic "Polytopic computations in constrained optimal control"
+    Automatika, 2009
+
     @param poly: polytope from which to subtract a region
     @param reg: region which should be subtracted
     @param abs_tol: absolute tolerance
@@ -2039,8 +2043,8 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
         return Polytope()
     # some constraints are active
     M = np.sum(mi)
-    if len(mi[0:len(mi) - 1]) > 0:
-        csum = np.cumsum(np.hstack([0, mi[0:len(mi) - 1]]))
+    if len(mi) - 1 > 0:
+        csum = np.cumsum(np.hstack([0, mi[0:-1]]))
         beg_mi = csum + m * np.ones(len(csum), dtype=int)
     else:
         beg_mi = np.array([m])
@@ -2059,21 +2063,28 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                 ax.figure.savefig('./img/res' + str(res_count) + '.pdf')
                 res_count += 1
         if counter[level] == 0:
+            # This is the first visit to this level
             if save:
                 logger.debug('counter[level] is 0')
 
+            # Go through all remaining polytopes that we want to remove and check whether any of them removes
+            # anything from the current set of hyperplanes (constraints)
             for j in xrange(level, N):
+                # Construct a set of constraints with the current hyperplanes and the hyperplanes of polytope j
+                # This is the intersection of the current hyperplanes and polytope j
                 auxINDICES = np.hstack([
                     INDICES,
                     range(beg_mi[j], beg_mi[j] + mi[j])
                 ])
                 Adummy = A[auxINDICES, :]
                 bdummy = B[auxINDICES]
+                # Will polytope j remove anything from the current set of hyperplanes?
                 R, _ = cheby_ball(Polytope(Adummy, bdummy))
                 if R > abs_tol:
+                    # Yes, constrain the set of constraints with the negation of one of polytope j's hyperplanes
                     level = j
                     counter[level] = 1
-                    INDICES = np.hstack([INDICES, beg_mi[level] + M])
+                    INDICES = np.hstack([INDICES, beg_mi[level] + M])  # Offset M negates hyperplanes
                     break
             if R < abs_tol:
                 # Since no polytope will remove anything, the current set of hyperplanes must be in the result
@@ -2088,25 +2099,36 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                     range(beg_mi[level], beg_mi[level] + mi[level])
                 ])
         else:
+            # We have been at this level before
             if save:
                 logger.debug('counter[level] > 0')
             # counter(level) > 0
             nzcount = np.nonzero(counter)[0]
+            # Start from the deepest level and pop out of it if we are done at that level
             for jj in xrange(len(nzcount) - 1, -1, -1):
                 level = nzcount[jj]
                 counter[level] += 1
+                # Have we checked all hyperplanes?
                 if counter[level] <= mi[level]:
+                    # No
+                    # We have already handled the negative side of the last hyperplane, so negate it to get the
+                    # positive side
                     INDICES[-1] -= M
+                    # Add the next negative hyperplane of the polytope of the current level
                     INDICES = np.hstack([
                         INDICES,
                         beg_mi[level] + counter[level] + M - 1
                     ])
+                    # Stay at this level, since we haven't checked all hyperplanes yet
                     break
                 else:
+                    # We have checked all hyperplanes at this level
+                    # Pop out of this level by resetting our states
                     counter[level] = 0
                     INDICES = INDICES[0:m + np.sum(counter)]
                     level -= 1
                     if level == -1:
+                        # We're done at all levels, return
                         if save:
                             if res:
                                 ax = res.plot()
@@ -2118,10 +2140,15 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                         return res
         test_poly = Polytope(A[INDICES, :], B[INDICES])
         rc, _ = cheby_ball(test_poly)
+        # Do we have a non-empty diff at this level?
         if rc > abs_tol:
             if level == N - 1:
+                # The diff is non-empty, and we have no more polytopes to remove.
+                # Add the current set of constraints to the result.
                 res = union(res, reduce(test_poly), False)
             else:
+                # The diff is non-empty, but we need to check whether the remaining polytopes remove anything.
+                # Go one level deeper to continue the search.
                 level += 1
     logger.debug('returning res from end')
     return res

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2077,7 +2077,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                     break
             if R < abs_tol:
                 level = level - 1
-                res = union(res, Polytope(A[INDICES, :], B[INDICES]), False)
+                res = union(res, reduce(Polytope(A[INDICES, :], B[INDICES])), False)
                 nzcount = np.nonzero(counter)[0]
                 for jj in xrange(len(nzcount) - 1, -1, -1):
                     if counter[level] <= mi[level]:

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2076,12 +2076,12 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                     INDICES = np.hstack([INDICES, beg_mi[level] + M])
                     break
             if R < abs_tol:
-                level = level - 1
+                level -= 1
                 res = union(res, reduce(Polytope(A[INDICES, :], B[INDICES])), False)
                 nzcount = np.nonzero(counter)[0]
                 for jj in xrange(len(nzcount) - 1, -1, -1):
                     if counter[level] <= mi[level]:
-                        INDICES[-1] = INDICES[-1] - M
+                        INDICES[-1] -= M
                         INDICES = np.hstack([
                             INDICES,
                             beg_mi[level] + counter[level] + M
@@ -2100,9 +2100,9 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
             nzcount = np.nonzero(counter)[0]
             for jj in xrange(len(nzcount) - 1, -1, -1):
                 level = nzcount[jj]
-                counter[level] = counter[level] + 1
+                counter[level] += 1
                 if counter[level] <= mi[level]:
-                    INDICES[-1] = INDICES[-1] - M
+                    INDICES[-1] -= M
                     INDICES = np.hstack([
                         INDICES,
                         beg_mi[level] + counter[level] + M - 1
@@ -2111,7 +2111,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                 else:
                     counter[level] = 0
                     INDICES = INDICES[0:m + np.sum(counter)]
-                    level = level - 1
+                    level -= 1
                     if level == -1:
                         if save:
                             if save:
@@ -2129,7 +2129,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
             if level == N - 1:
                 res = union(res, reduce(test_poly), False)
             else:
-                level = level + 1
+                level += 1
     logger.debug('returning res from end')
     return res
 

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2114,13 +2114,12 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                     level -= 1
                     if level == -1:
                         if save:
-                            if save:
-                                if res:
-                                    ax = res.plot()
-                                    ax.axis([0.0, 1.0, 0.0, 2.0])
-                                    ax.figure.savefig('./img/res_returned'
-                                                      + str(res_count)
-                                                      + '.pdf')
+                            if res:
+                                ax = res.plot()
+                                ax.axis([0.0, 1.0, 0.0, 2.0])
+                                ax.figure.savefig('./img/res_returned'
+                                                  + str(res_count)
+                                                  + '.pdf')
                             logger.debug('returning res from 2nd point')
                         return res
         test_poly = Polytope(A[INDICES, :], B[INDICES])

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2089,7 +2089,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                         break
                     else:
                         counter[level] = 0
-                        INDICES = INDICES[0:m + sum(counter)]
+                        INDICES = INDICES[0:m + np.sum(counter)]
                         if level == -1:
                             logger.debug('returning res from 1st point')
                             return res

--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2081,8 +2081,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                 nzcount = np.nonzero(counter)[0]
                 for jj in xrange(len(nzcount) - 1, -1, -1):
                     if counter[level] <= mi[level]:
-                        INDICES[len(INDICES) -
-                                1] = INDICES[len(INDICES) - 1] - M
+                        INDICES[-1] = INDICES[-1] - M
                         INDICES = np.hstack([
                             INDICES,
                             beg_mi[level] + counter[level] + M
@@ -2103,7 +2102,7 @@ def region_diff(poly, reg, abs_tol=ABS_TOL, intersect_tol=ABS_TOL,
                 level = nzcount[jj]
                 counter[level] = counter[level] + 1
                 if counter[level] <= mi[level]:
-                    INDICES[len(INDICES) - 1] = INDICES[len(INDICES) - 1] - M
+                    INDICES[-1] = INDICES[-1] - M
                     INDICES = np.hstack([
                         INDICES,
                         beg_mi[level] + counter[level] + M - 1

--- a/tests/polytope_test.py
+++ b/tests/polytope_test.py
@@ -486,5 +486,169 @@ def is_glpk_present():
         return False
 
 
+def test_simple_region_diff():
+    # Test region_diff with very simple input
+    # Set up a square and remove half of it
+    domain = pc.Polytope.from_box([(0., 1.), (0., 1.)])
+    region = pc.Region([pc.Polytope.from_box([(0., 0.5), (0., 1.)])])
+
+    diff = pc.polytope.region_diff(domain, region)
+    remaining = pc.Polytope.from_box([(0.5, 1.), (0., 1.)])
+    assert diff == remaining, "Expected {}, but got {}".format(remaining, diff)
+
+
+def test_convex_region_diff_1():
+    # Test region_diff when the output should be one polytope
+    # Set up a square and remove 3/4 by subtracting 2 boxes
+    domain = pc.Polytope.from_box([(0., 1.), (0., 1.)])
+    region = pc.Region([
+        pc.Polytope.from_box([(0., 0.5), (0., 1.)]),
+        pc.Polytope.from_box([(0., 1.), (0., 0.5)]),
+    ])
+
+    diff = pc.polytope.region_diff(domain, region)
+    remaining = pc.Polytope.from_box([(0.5, 1.), (0.5, 1.)])
+    assert diff == remaining, "Expected {}, but got {}".format(remaining, diff)
+
+
+def test_convex_region_diff_2():
+    # Test region_diff when the output should be one polytope
+    # Set up a square and remove 3/4 by subtracting 3 boxes
+    domain = pc.Polytope.from_box([(0., 1.), (0., 1.)])
+    region = pc.Region([
+        pc.Polytope.from_box([(0., 0.5), (0.5, 1.)]),
+        pc.Polytope.from_box([(0.5, 1.), (0., 0.5)]),
+        pc.Polytope.from_box([(0., 0.5), (0., 0.5)]),
+    ])
+
+    diff = pc.polytope.region_diff(domain, region)
+    remaining = pc.Polytope.from_box([(0.5, 1.), (0.5, 1.)])
+    assert diff == remaining, "Expected {}, but got {}".format(remaining, diff)
+
+
+def test_non_convex_region_diff():
+    # Test region_diff when the output should be non-convex
+    # Set up a square and remove 1/4 by subtracting 1 square box
+    domain = pc.Polytope.from_box([(0., 1.), (0., 1.)])
+    region = pc.Region([
+        pc.Polytope.from_box([(0., 0.5), (0., 0.5)])
+    ])
+
+    diff = pc.polytope.region_diff(domain, region)
+    remaining1 = pc.Polytope.from_box([(0.5, 1.), (0., 1.)])
+    remaining2 = pc.Polytope.from_box([(0., 0.5), (0.5, 1.)])
+    assert not pc.is_empty(diff.diff(remaining1)), diff
+    assert not pc.is_empty(diff.diff(remaining2)), diff
+    assert pc.is_empty(diff.diff(remaining1).diff(remaining2)), diff
+
+
+def test_checker_region_diff():
+    # Test region_diff when the output should be non-convex
+    # Set up a square and remove 1/2 by subtracting 2 square box on the diagonal
+    domain = pc.Polytope.from_box([(0., 1.), (0., 1.)])
+    region = pc.Region([
+        pc.Polytope.from_box([(0., 0.5), (0., 0.5)]),
+        pc.Polytope.from_box([(0.5, 1.), (0.5, 1.)]),
+    ])
+
+    diff = pc.polytope.region_diff(domain, region)
+    remaining1 = pc.Polytope.from_box([(0.5, 1.), (0., .5)])
+    remaining2 = pc.Polytope.from_box([(0., 0.5), (0.5, 1.)])
+    assert not pc.is_empty(diff.diff(remaining1)), diff
+    assert not pc.is_empty(diff.diff(remaining2)), diff
+    assert pc.is_empty(diff.diff(remaining1).diff(remaining2)), diff
+
+
+def test_triangles_region_diff():
+    # Test region_diff when the output should be convex
+
+    poly_region = pc.Region()
+
+    # First polytope to remove is (0, 0) -- (3, 0) -- (3, 1) -- (1, 1) -- (0, 0)
+    a = np.array([
+        [-1., 1.],
+        [0., -1.],
+        [1., 0.],
+        [0., 1.]
+    ])
+    b = np.array([
+        0.,
+        0.,
+        3.,
+        1.
+    ])
+
+    poly_region = poly_region.union(pc.Polytope(a, b), check_convex=False)
+    # Second polytope to remove is (3, 0) -- (4, 0) -- (3, 1) -- (3, 0)
+    a = np.array([
+        [-1., 0.],
+        [0., -1.],
+        [1., 1.]
+    ])
+    b = np.array([
+        -3.,
+        0.,
+        4.
+    ])
+
+    poly_region = poly_region.union(pc.Polytope(a, b), check_convex=False)
+    # Third polytope to remove is (4, 0) -- (4, 1) -- (3, 1) -- (4, 0)
+    a = np.array([
+        [1., 0.],
+        [0., 1.],
+        [-1., -1.]
+    ])
+    b = np.array([
+        4.,
+        1.,
+        -4.
+    ])
+
+    poly_region = poly_region.union(pc.Polytope(a, b), check_convex=False)
+    # Fourth polytope to remove is (3, 1) -- (4, 1) -- (4, 4) -- (3, 3) -- (3, 1)
+    a = np.array([
+        [1., 0.],
+        [-1., 0.],
+        [0., -1.],
+        [-1., 1.]
+    ])
+    b = np.array([
+        4.,
+        -3.,
+        -1.,
+        0.
+    ])
+
+    poly_region = poly_region.union(pc.Polytope(a, b), check_convex=False)
+
+    # The polytope to remove from is (0, 0) -- (4, 0) -- (4, 4) -- (0, 0)
+    a = np.array([
+        [1., 0.],
+        [0., -1.],
+        [-1., 1.],
+    ])
+    b = np.array([
+        4.,
+        0.,
+        0.,
+    ])
+    poly_domain = pc.Polytope(a, b)
+
+    poly_diff = poly_domain.diff(poly_region)
+
+    a = np.array([
+        [-1., 1.],
+        [1., 0.],
+        [0., -1.],
+    ])
+    b = np.array([
+        0.,
+        3.,
+        -1.,
+    ])
+    remaining_poly = pc.Polytope(a, b)
+    assert poly_diff == remaining_poly, poly_diff
+
+
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
The purpose of the function `region_diff()` is to remove a set of polytopes (a region, the subtrahend) from one polytope (the minuend). The result may be a single polytope if the result is convex, or multiple polytopes (a single region).

The function `region_diff()` does not produce the correct result for certain input. For instance, when the minuend is a unit square and the subtrahend is two squares with side 0.5 positioned at `[(0, 0), (0.5, 0.5)]` and `[(0.5, 0.5), (1, 1)]`, the result produced by `region_diff()` incorrectly includes the square `[(0, 0), (0.5, 0.5)]`. The issue is the code that prunes the search tree when none of the remaining polytopes removes anything from the current set of hyperplanes.

The algorithm is a depth first search algorithm implemented in a while loop. It has a set of hyperplanes which is initialized to the minuend. It then works by branching on the hyperplanes of the subtrahend. At each branchin point the set of hyperplanes is partitioned into two by one of the hyperplanes of the subtrahend.

A recursive version of the algorithm is described in Algorithm 2 in:

> Mato Baotic "Polytopic computations in constrained optimal control"
> Automatika, 2009

When none of the remaining polytopes intersects the current set of hyperplanes, some things hold:
- the current set of hyperplanes is a non-empty partition and is obviously part of the difference
- the algorithm is done in the current branch
- the other partition is empty, since the intersection between the current set of hyperplanes and the subtrahend is empty

This PR:
- adds tests to assert correctness of some simple cases
- adds one test that fails without this fix
- tries to improve the readability a bit
- adds comments
- fixes the failing test case