### PR TITLE
cases: bounding box for unbounded polytope, bounding box for empty polytope

### DIFF
--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2330,7 +2330,10 @@ def _get_patch(poly1, **kwargs):
     angle = angle * corr
     ind = np.argsort(angle)
     # create patch
-    patch = mpl.patches.Polygon(V[ind, :], True, **kwargs)
+    patch = mpl.patches.Polygon(
+        V[ind, :],
+        closed=True,
+        **kwargs)
     patch.set_zorder(0)
     return patch
 


### PR DESCRIPTION
For an unbounded polytope, the bounding box has infinite dimensions. For an empty polytope the bounding box is 0, 0. This change follows commit 7f5964597d1bdc3bf59b8f18bdcce9087c928b21, before which 0, 0 were used as endpoints in all these cases. In `tulip` relevant tests pass with these changes.