### PR TITLE
Add Python 3.12 to CI version matrix; upgrade CI action dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
                     '3.9',
                     '3.10',
                     '3.11',
+                    '3.12',
                     ]
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
                     '3.12',
                     ]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Install APT packages
               run: |
                 sudo apt update
@@ -36,7 +36,7 @@ jobs:
                     libmpfr-dev \
                     libglpk-dev
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies from PyPI

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
     'Topic :: Software Development']
 


### PR DESCRIPTION
* Python 3.12 is the current release of Python, so we should start testing with it.
* actions/setup-python and actions/checkout use an older version of Node.js that is deprecated in GitHub Actions images, as indicated in the warning message in recent CI builds, e.g., https://github.com/tulip-control/polytope/actions/runs/10714561602