### PR TITLE
MNT: compatibility with `numpy >= 2.4.0`

### DIFF
--- a/polytope/polytope.py
+++ b/polytope/polytope.py
@@ -2377,7 +2377,7 @@ def grid_region(polyreg, res=None):
     if res is None:
         density = 8
         res = [
-            math.ceil(density * (b - a))
+            math.ceil(density * (b[0] - a[0]))
             for a, b in zip(*bbox)]
     if len(res) != polyreg.dim:
         raise ValueError((

--- a/polytope/version.py
+++ b/polytope/version.py
@@ -32,7 +32,7 @@
 """polytope package version"""
 import os.path
 
-version_info = (0, 2, 5)
+version_info = (0, 2, 6)
 
 version = '.'.join([str(x) for x in version_info])
 


### PR DESCRIPTION
- MNT: compatibility with `numpy >= 2.4.0`, by [extracting a single element from the array](https://numpy.org/doc/stable/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar). In `numpy < 2.4.0`, the 1-element array was implicitly converted to a Python scalar.

- REL: change `polytope` version number